### PR TITLE
Fix broken eventemitter typing

### DIFF
--- a/typings/pixi-audio.d.ts
+++ b/typings/pixi-audio.d.ts
@@ -16,7 +16,7 @@ declare module PIXI {
       resume():void;
     }
 
-    export class Audio extends EventEmitter{
+    export class Audio extends utils.EventEmitter{
       constructor(data:HTMLAudioElement|AudioBuffer, manager:AudioManager);
       manager:AudioManager;
       data:AudioBuffer|HTMLAudioElement;


### PR DESCRIPTION
Typescript 2.0 doesn't seem to like the shorthand type decleration for EventEmitter in pixi-audio.d.ts